### PR TITLE
pass logger to patchOpts

### DIFF
--- a/internal/controller/runtime/fsm/runtime_fsm_patch_shoot.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_patch_shoot.go
@@ -48,6 +48,7 @@ func sFnPatchExistingShoot(ctx context.Context, m *fsm, s *systemState) (stateFn
 		Resources:            s.shoot.Spec.Resources,
 		InfrastructureConfig: s.shoot.Spec.Provider.InfrastructureConfig,
 		ControlPlaneConfig:   s.shoot.Spec.Provider.ControlPlaneConfig,
+		Log: ptr.To(m.log),
 	})
 
 	if err != nil {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- pass logger to patchOpts in order to fix nil logger in the `provider.go`
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

#685